### PR TITLE
Export template

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,13 +130,14 @@
     "msazurermtools.azurerm-vscode-tools"
   ],
   "dependencies": {
+    "azure-arm-keyvault": "0.11.4",
     "azure-arm-resource": "1.5.1-preview",
     "azure-arm-storage": "^0.13.4-preview",
     "azure-arm-website": "0.11.4",
-    "azure-arm-keyvault": "0.11.4",
     "azure-gallery": "^2.0.0-pre.20",
     "copy-paste": "^1.3.0",
     "download-file": "^0.1.5",
+    "fs-path": "0.0.23",
     "get-urls": "^5.0.1",
     "ms-rest-azure": "1.15.2",
     "octonode": "^0.7.7",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,12 @@
         "command": "deployTemplate",
         "title": "Deploy one of the Azure Resource Manager (ARM) templates in your workspace",
         "category": "Azure"
-      }      
+      },
+      {
+        "command": "exportTemplate",
+        "title": "Export one of your Resource Groups as a template saved in your workspace",
+        "category": "Azure"
+      }
     ]
   },
   "scripts": {

--- a/src/azure.js
+++ b/src/azure.js
@@ -8,6 +8,23 @@ var fs = require('fs');
 var config = require('./config');
 var constants = config.getConstants();
 
+exports.exportTemplate = function exportTemplate(state) {
+    return new Promise((resolve, reject) => {
+        var resourceClient = new ResourceManagement.ResourceManagementClient(state.credentials, state.selectedSubscriptionId);
+        resourceClient.resourceGroups.exportTemplate(state.resourceGroupToUse, {
+            resources: ["*"],
+            options: "IncludeParameterDefaultValue"
+        }, (err, result, request, response) => {
+            if (err) {
+                reject(err);
+            }
+            else {
+                resolve(result);
+            }
+        });
+    });
+};
+
 exports.deployTemplate = function deployTemplate(state) {
     return new Promise((resolve, reject) => {
         var resourceGroupName = state.resourceGroupToUse;
@@ -71,18 +88,18 @@ exports.createNewResourceGroup = function createNewResourceGroup(state) {
 exports.createNewKeyVault = function createNewKeyVault(state) {
     return new Promise(function (resolve, reject) {
         var keyVaultClient = new KeyVaultManagement(state.credentials, state.selectedSubscriptionId);
-        var keyVaultParameters  =  {
-            location :  state.selectedRegion,
-            properties :  {
-                sku :  {
-                    family :  'A',
-                    name :  'standard'
+        var keyVaultParameters = {
+            location : state.selectedRegion,
+            properties : {
+                sku : {
+                    family : 'A',
+                    name : 'standard'
                 },
-                accessPolicies :  [],
-                enabledForDeployment :  false,
+                accessPolicies : [],
+                enabledForDeployment : false,
                 tenantId: state.subscriptions.find(x => x.id === state.selectedSubscriptionId).tenantId
             },
-            tags :  {}
+            tags : {}
         };
         keyVaultClient.vaults.createOrUpdate(state.resourceGroupToUse, state.keyVaultName, keyVaultParameters, null,
             function (err, result) {

--- a/src/commands/deployTemplate.js
+++ b/src/commands/deployTemplate.js
@@ -20,14 +20,14 @@ exports.createCommand = function createCommand(state) {
                     reject(constants.promptNoWorkspaceOpen);
                 }
 
-                var srcpath = vscode.workspace.rootPath + '/arm-templates';
+                var srcpath = path.join(vscode.workspace.rootPath, constants.armTemplatesPath);
                 var directories = fs.readdirSync(srcpath).filter(function (file) {
                     return fs.statSync(path.join(srcpath, file)).isDirectory();
                 });
 
                 vscode.window.showQuickPick(directories).then((selectedTemplate) => {
-                    state.SelectedTemplateFile = vscode.workspace.rootPath + '\\arm-templates\\' + selectedTemplate + '\\azuredeploy.json';
-                    state.SelectedTemplateParametersFile = vscode.workspace.rootPath + '\\arm-templates\\' + selectedTemplate + '\\azuredeploy.parameters.json';
+                    state.SelectedTemplateFile = path.join(vscode.workspace.rootPath, 'arm-templates', selectedTemplate ,'azuredeploy.json');
+                    state.SelectedTemplateParametersFile = path.join(vscode.workspace.rootPath, 'arm-templates', selectedTemplate, 'azuredeploy.parameters.json');
 
                     state.selectedTemplateName = selectedTemplate;
 

--- a/src/commands/exportTemplate.js
+++ b/src/commands/exportTemplate.js
@@ -1,0 +1,16 @@
+var vscode = require('vscode');
+var ux = require('../ux');
+var config = require('../config');
+var azure = require('../azure');
+var constants = config.getConstants();
+var open = require('open');
+var path = require('path');
+var fs = require('fs');
+
+exports.createCommand = function createCommand(state) {
+    vscode.commands.registerCommand('exportTemplate', function () {
+        ux.isLoggedIn(state).then(() => {
+            ux.exportTemplate(state);
+        });
+    });
+};

--- a/src/commands/searchQuickStartsGallery.js
+++ b/src/commands/searchQuickStartsGallery.js
@@ -6,6 +6,7 @@ var client = github.client();
 var githubSearch = client.search();
 var constants = config.getConstants();
 var download = require('download-file');
+var path = require('path');
 
 exports.createCommand = function createCommand(state) {
     vscode.commands.registerCommand('searchQuickStartsGallery', function () {
@@ -42,7 +43,7 @@ exports.createCommand = function createCommand(state) {
                         if (vscode.workspace.rootPath) {
                             if (selectedTemplate && selectedTemplate.length > 0) {
                                 var options = {
-                                    directory: vscode.workspace.rootPath + '/arm-templates/' + selectedItem,
+                                    directory: path.join(vscode.workspace.rootPath, 'arm-templates', selectedItem),
                                     filename: selectedTemplate[0].name
                                 };
 
@@ -74,7 +75,7 @@ function downloadTemplate(url, options) {
                 reject();
             }
             else {
-                vscode.workspace.openTextDocument(options.directory + '/azuredeploy.json')
+                vscode.workspace.openTextDocument(path.join(options.directory, 'azuredeploy.json'))
                     .then(doc => {
                         vscode.window.showTextDocument(doc);
                         resolve();
@@ -95,7 +96,7 @@ function downloadTemplateParameters(url, options) {
                 reject();
             }
             else {
-                vscode.workspace.openTextDocument(options.directory + '/azuredeploy.parameters.json')
+                vscode.workspace.openTextDocument(path.join(options.directory, 'azuredeploy.parameters.json'))
                     .then(prms => {
                         vscode.window.showTextDocument(prms);
                         resolve();

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ const vscode = require('vscode');
 
 exports.getConstants = function getConstants() {
     return {
+        armTemplatesPath: 'arm-templates',
         btnRegionSelectionLabel: 'Select your desired Azure region. ',
         btnStorageSelectionLabel: 'Select your desired Azure Storage Account. ',
         loginButtonLabel: 'Sign In',
@@ -59,6 +60,8 @@ exports.getConstants = function getConstants() {
         promptDeployingTemplateCompleted: 'Template {0} deployment to resource group {1} completed with status of {2}',
         promptDeployingTemplateFailed: 'FAILED to deploy template {0} to resource group {1}',
         promptNotLoggedIn : 'You have not yet logged in. Run the Azure Login command first.',
+        promptTemplateExported: 'Resource group {0} has been exported to your workspace\'s arm-templates folder',
+        promptTemplateExportedWithErrors: 'Resource group {0} has been exported with errors. Check the template for completeness.',
         btnLabelNewRg: 'New',
         btnLabelExistingRg: 'Existing',
         optionNewRg: 'Create new resource group',

--- a/src/extension.js
+++ b/src/extension.js
@@ -86,6 +86,9 @@ function activate(context) {
     // deploy a template that's open in the editor
     var deployTemplate = require('./commands/deployTemplate').createCommand(state);
 
+    // export a resource group to a template file
+    var exportTemplate = require('./commands/exportTemplate').createCommand(state);
+
     context.subscriptions.push(loginToAzureCommand);
     context.subscriptions.push(selectSubscriptionCommand);
     context.subscriptions.push(selectRegionCommand);
@@ -99,6 +102,7 @@ function activate(context) {
     context.subscriptions.push(storageAccountCreateSimpleCommand);
     context.subscriptions.push(searchQuickStartsGallery);
     context.subscriptions.push(deployTemplate);
+    context.subscriptions.push(exportTemplate);
     context.subscriptions.push(createKeyVaultCommandSimple);
 }
 exports.activate = activate;

--- a/src/ux.js
+++ b/src/ux.js
@@ -3,6 +3,29 @@ var config = require('./config');
 var constants = config.getConstants();
 var azure = require('./azure');
 
+// perform the export template feature
+exports.exportTemplate = function exportTemplate(state) {
+    this.getResourceGroups(state)
+        .then(function () {
+            vscode.window.showQuickPick(state.resourceGroupList)
+                .then(function (selectedRg) {
+                    if (!selectedRg) reject();
+                    state.resourceGroupToUse = selectedRg;
+
+                    azure.exportTemplate(state)
+                        .then((result) => {
+                            console.log(result);
+                        })
+                        .catch((err) => {
+                            console.log(err);
+                        });
+                });
+        })
+        .catch(function (err) {
+            vscode.window.showErrorMessage(err);
+        });
+};
+
 // check to see if the user is logged in
 exports.isLoggedIn = function isLoggedIn(state) {
     return new Promise((resolve, reject) => {

--- a/src/ux.js
+++ b/src/ux.js
@@ -2,6 +2,7 @@ var vscode = require('vscode');
 var config = require('./config');
 var constants = config.getConstants();
 var azure = require('./azure');
+var path = require('path');
 
 // perform the export template feature
 exports.exportTemplate = function exportTemplate(state) {
@@ -15,9 +16,13 @@ exports.exportTemplate = function exportTemplate(state) {
                     azure.exportTemplate(state)
                         .then((result) => {
                             console.log(result);
-                        })
-                        .catch((err) => {
-                            console.log(err);
+                            var json = JSON.stringify(result.template);
+                            if (result.error) {
+                                vscode.window.showErrorMessage(constants.promptTemplateExportedWithErrors.replace('{0}',state.resourceGroupToUse));
+                            }
+                            else {
+                                vscode.window.showInformationMessage(constants.promptTemplateExported.replace('{0}',state.resourceGroupToUse));
+                            }
                         });
                 });
         })

--- a/src/ux.js
+++ b/src/ux.js
@@ -29,7 +29,6 @@ exports.exportTemplate = function exportTemplate(state) {
                                 vscode.workspace.openTextDocument(filename)
                                 .then(prms => {
                                     vscode.window.showTextDocument(prms);
-                                    resolve();
                                 });
                             });
                         });

--- a/src/ux.js
+++ b/src/ux.js
@@ -16,7 +16,6 @@ exports.exportTemplate = function exportTemplate(state) {
                     state.resourceGroupToUse = selectedRg;
                     azure.exportTemplate(state)
                         .then((result) => {
-                            console.log(result);
                             var json = JSON.stringify(result.template);
                             var filename = path.join(vscode.workspace.rootPath, constants.armTemplatesPath, state.resourceGroupToUse, 'azuredeploy.json');
                             fsPath.writeFile(filename, json, (err) => {


### PR DESCRIPTION
would like to have any of the contributors - @cmatskas @tripdubroot @avodovnik - test this out and see if the export feature is working. Note - in my own tests via the tool AND the portal i noticed that similar output issues exist, as well as errors coming from the API. Seems to demonstrate the export template API will be evolving. I'll check on the status of this to see if we can get more information on how to interrogate the errors and more gracefully handle. 

If we think the tool doing the same thing the portal, cli, and sdk do, i think this is an MVP for this feature. It'd definitely give customers an easier way of snapshotting a resource group for re-creation. 

Thanks for your time testing if you can devote it. 