### PR TITLE
Added new option to change behavior of opening console at startup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ jspm_packages
 
 # git merge/diff files
 *.orig
+
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "bradygaster",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bradygaster/azure-tools-vscode.git"
+    "url": "git+https://github.com/bradygaster/azure-tools-vscode.git"
   },
   "bugs": {
     "url": "https://github.com/bradygaster/azure-tools-vscode/issues"
@@ -44,6 +44,11 @@
           "type": "boolean",
           "default": true,
           "description": "To opt out of sending basic usage telemetry set this to false. Default is true."
+        },
+        "azure.startAutomatically": {
+          "type": "boolean",
+          "default": true,
+          "description": "Starts Azure Tools integrated console features automatically set this to true. Default is true."
         }
       }
     },
@@ -134,7 +139,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
-    "vscode": "^0.11.0"
+    "vscode": "^0.11.18"
   },
   "extensionDependencies": [
     "msazurermtools.azurerm-vscode-tools",
@@ -159,5 +164,11 @@
     "ms-rest-azure": "1.15.2",
     "octonode": "^0.7.7",
     "open": "0.0.5"
-  }
+  },
+  "homepage": "https://github.com/bradygaster/azure-tools-vscode#readme",
+  "directories": {
+    "test": "test"
+  },
+  "author": "",
+  "license": "ISC"
 }

--- a/src/config.js
+++ b/src/config.js
@@ -21,9 +21,19 @@ exports.isTelemetryEnabled = function isTelemetryEnabled() {
     return true;
 };
 
+exports.isStartAutomatically = function isStartAutomatically() {
+    var f = vscode.workspace.getConfiguration('azure');
+    if (f != null)
+        if (f.startAutomatically != null)
+	   if (typeof (f.startAutomatically) === "boolean")
+                return f.startAutomatically
+
+    return true;
+};
+
 exports.wireUpServiceClientTelemetry = (serviceClient) => {
     var package = require('./../package.json');
-    var clientVersion = require('util').format('%s/%s', 
+    var clientVersion = require('util').format('%s/%s',
         package.name,
         package.version);
     serviceClient.addUserAgentInfo(clientVersion);

--- a/src/outputChannel.js
+++ b/src/outputChannel.js
@@ -1,4 +1,5 @@
 var vscode = require('vscode');
+var config = require('./config');
 
 var channel = null;
 
@@ -6,7 +7,9 @@ function newChannel() {
     console.log('new channel');
 
     channel = vscode.window.createOutputChannel('Azure Tools');
-    channel.show();
+    if (config.isStartAutomatically())
+        channel.show();
+
     return channel;
 }
 


### PR DESCRIPTION
Added azure.startAutomatically option to change a behavior of opening Azure Tools integrated console at startup. If true, open console.
This patch will be fixed https://github.com/bradygaster/azure-tools-vscode/issues/42.

## Motivation
I use vs code for git editor. In such a light usage.  Is a problem console is open at the time of start-up of the editor. Slow and focus moves.

## A question
1. I would like to disable console by default. However, this patch is the same as existing.
2. I think there is a better name for option names. This name has the same name as a similar function of PowerShell extension. I have no good idea.
