### PR TITLE
Add showToolsWindowOnStartup setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
           "type": "boolean",
           "default": true,
           "description": "To opt out of sending basic usage telemetry set this to false. Default is true."
+        },
+        "azure.showToolsWindowOnStartup": {
+          "type": "boolean",
+          "default": true,
+          "description": "To prevent the Azure Tools panel showing on startup set this to false. Default is true"
         }
       }
     },

--- a/src/config.js
+++ b/src/config.js
@@ -21,6 +21,15 @@ exports.isTelemetryEnabled = function isTelemetryEnabled() {
     return true;
 };
 
+exports.showToolsWindowOnStartup = function showToolsWindowOnStartup() {
+    var f = vscode.workspace.getConfiguration('azure');
+    if (f != null)
+        if (f.showToolsWindowOnStartup != null)
+            if (typeof (f.showToolsWindowOnStartup) === "boolean")
+                return f.showToolsWindowOnStartup
+
+    return true;
+};
 exports.wireUpServiceClientTelemetry = (serviceClient) => {
     var package = require('./../package.json');
     var clientVersion = require('util').format('%s/%s', 

--- a/src/outputChannel.js
+++ b/src/outputChannel.js
@@ -1,4 +1,6 @@
 var vscode = require('vscode');
+var config = require('./config');
+
 
 var channel = null;
 
@@ -6,7 +8,9 @@ function newChannel() {
     console.log('new channel');
 
     channel = vscode.window.createOutputChannel('Azure Tools');
-    channel.show();
+    if (config.showToolsWindowOnStartup()) {
+        channel.show();
+    }
     return channel;
 }
 


### PR DESCRIPTION
Setting azure.showToolsWindowOnStartup to false prevents the Azure Tools panel (outputChannel) being displayed on startup