### PR TITLE
Check workspace has folder open

### DIFF
--- a/src/commands/azure.template-export.js
+++ b/src/commands/azure.template-export.js
@@ -9,7 +9,10 @@ exports.createCommand = function createCommand(state) {
     vscode.commands.registerCommand('azure.template-export', function () {
         ux.isLoggedIn(state)
             .then(() => {
-                ux.exportTemplate(state);
+                ux.isFolderOpen()
+                    .then(() => {
+                        ux.exportTemplate(state);
+                    });
             });
     });
 };

--- a/src/ux.js
+++ b/src/ux.js
@@ -65,6 +65,18 @@ exports.isLoggedIn = function isLoggedIn(state) {
         }
     });
 };
+exports.isFolderOpen = function isFolderOpen() {
+    var promptNoRootFolder = 'You do not currently have a folder open in the workspace. Please open a folder first.';
+
+    return new Promise((resolve, reject) => {
+        if (vscode.workspace.rootPath !== undefined) {
+            resolve();
+        }
+        else {
+            vscode.window.showErrorMessage(promptNoRootFolder);
+        }
+    });
+}
 
 // deploys arm template
 exports.deployTemplate = function deployTemplate(state) {


### PR DESCRIPTION
Exporting a template uses the workspace rootPath to determine where to place the generated template. Add a check that we have a folder open before exporting to give a helpful error to the user if not